### PR TITLE
fix: span closing tag

### DIFF
--- a/markdown/html5.md
+++ b/markdown/html5.md
@@ -411,7 +411,7 @@ However, the **&lt;span&gt;** element should only be used if no other, more *sem
 
 ```html
 One of the boldest colors in the spectrum, 
-<span class="color">red</color> stands out 
+<span class="color">red</span> stands out 
 in any work of art, hence its use to signal 
 danger or warning.
 ```


### PR DESCRIPTION
This pull request fixes the closing tag of a span element in the slide titled "Spans".