### PR TITLE
Fix typos in HTML5 slides

### DIFF
--- a/markdown/html5.md
+++ b/markdown/html5.md
@@ -1092,7 +1092,7 @@ How do you get to school?<br>
 
 # Radio Button
 
-* A <a href="https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)">radio</a> allows the selecting one form several choices.
+* A <a href="https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)">radio</a> allows selecting **one** from several choices.
 * If a radio button is **selected**, then its name/value pair is submitted to the server.
 * If a radio button is **not selected**, nothing is submitted.
 * If two radio buttons have the **same name**, then only one can be selected; they form a selection group.

--- a/markdown/html5.md
+++ b/markdown/html5.md
@@ -982,7 +982,7 @@ There are several different types of inputs just for normal text entry.
 * <a href="https://html.spec.whatwg.org/multipage/input.html#telephone-state-(type=tel)">tel</a>: input value is a telephone number
 * <a href="https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)">search</a>: input value is used to perform a search
 * <a href="https://html.spec.whatwg.org/multipage/input.html#url-state-(type=url)">url</a>: input value is an URL
-* <a href="https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)">email</a>: input value is used an e-mail
+* <a href="https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)">email</a>: input value is an e-mail address
 ]
 
 Some browsers may use slightly different controls for each type.


### PR DESCRIPTION
Fix the following typos that I found in the HTML5 slides while studying:

### Text Inputs
#### Slide 51

Fix the sentence below:

| Before | After |
|:-------:|:------:|
| ![image](https://github.com/arestivo/slides/assets/93825634/558cdcfc-9ef1-4cdd-a898-17f39bc9870a) | **email:** the input value is an e-mail address |

### Radio Button
#### Slide 56

Change the **radio button** description:

| Before | After |
|:-------:|:------:|
| ![image](https://github.com/arestivo/slides/assets/93825634/23439497-9110-4df2-95df-eccca32dd9d3) | A [radio](https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)) allows selecting **one** from several choices. |