### PR TITLE
Fix typos in PHP and JavaScript slides

### DIFF
--- a/markdown/javascript.md
+++ b/markdown/javascript.md
@@ -1544,7 +1544,7 @@ The [map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Gl
 ```javascript
 const numbers = [4, 8, 15, 16, 23, 42]
 const doubled = numbers.map(function(n) { return n * 2 })
-console.log(doubled) // 8, 16, 30, 32, 46, 84
+console.log(doubled) // [8, 16, 30, 32, 46, 84]
 ```
 
 Or using **arrow functions**:
@@ -1552,7 +1552,7 @@ Or using **arrow functions**:
 ```javascript
 const numbers = [4, 8, 15, 16, 23, 42]
 const doubled = numbers.map(n => n * 2)
-console.log(doubled) // 8, 16, 30, 32, 46, 84
+console.log(doubled) // [8, 16, 30, 32, 46, 84]
 ```
 
 ---
@@ -1818,7 +1818,7 @@ console.log(set.has('Jane Doe'))  // false
 We can loop over the elements in a Set using **for ... of** loops:
 
 ```javascript
-const set = new Map(['John Doe', 'Jane Doe'])
+const set = new Set(['John Doe', 'Jane Doe'])
 for (const element of set) 
   console.log(element)
 ```

--- a/markdown/javascript.md
+++ b/markdown/javascript.md
@@ -438,7 +438,7 @@ template: inverse
 
 ```javascript
 if (condition) {
-  //do domething
+  //do something
 } else {
   //something else
 }
@@ -943,7 +943,7 @@ const foo = bar.bind(3)
 foo(1, 2) // 1 2 3
 ```
 
-It can also be used to bind **parameters**. In this case it returns a function with only one parameter:
+It can also be used to bind **parameters**. In this case, it returns a function with only one parameter:
 
 ```javascript
 const baz = bar.bind('this', 'first')
@@ -1147,7 +1147,7 @@ template: inverse
 
 * For example, we can do complicated meta-programming by manipulating the prototype chain.
 
-* The original decision to use prototypes instead of classes in JavaScript as to do mainly with performance.
+* The original decision to use prototypes instead of classes in JavaScript has to do mainly with performance.
 
 But why choose **one** when we can have **both**?
 

--- a/markdown/php.md
+++ b/markdown/php.md
@@ -71,7 +71,7 @@ The infamous hello world example in PHP:
 or even shorter
 
 ```php
-<?='Hello World;
+<?='Hello World'?>
 ```
 
 ---
@@ -168,7 +168,7 @@ name: variables
 
 * Variables are represented by a dollar sign followed by the variable's name.
 * The variable's name is **case-sensitive**.
-* There are no explicit type definition in variable declarations.
+* There are no explicit type definitions in variable declarations.
 * A variable's type is determined by the context in which the variable is used.
 
 ```php
@@ -259,7 +259,7 @@ The [isset](https://www.php.net/manual/en/function.isset.php) function determine
 $bar = isset($bar) ? $bar : $some_default_value;
 ```
 
-An easier way to acccomplish this would be to use the *null coalesce* operator:
+An easier way to accomplish this would be to use the *null coalesce* operator:
 
 ```php
 $bar = $bar ?? $some_default_value;
@@ -1109,7 +1109,7 @@ class Car {
 
 Methods are like functions that have access to the private properties of the class. They also have the same visibility keywords as properties.
 
-However, due to the dynamic typed nature of PHP, to access these properties the pseudo-variable **$this** must be used:
+However, due to the dynamically typed nature of PHP, to access these properties the pseudo-variable **$this** must be used:
 
 ```php
 class Car {
@@ -1522,7 +1522,7 @@ PDO offers you a choice of 3 different error handling strategies:
 * **PDO::ERRMODE_SILENT** The default mode. No error is shown. You can use the errorCode()
   and errorInfo() on both database and statement objects to inspect the error.
 
-* **PDO::ERRMODE_WARNING** Similar to previous one but a warning is shown.
+* **PDO::ERRMODE_WARNING** Similar to the previous one but a warning is shown.
 
 * **PDO::ERRMODE_EXCEPTION** In addition to setting the error code, PDO will throw a PDOException and set its properties to reflect the error code and error information.
 
@@ -1881,7 +1881,7 @@ $encoded = json_encode($posts);
 $decoded = json_decode($encoded); //$decoded === $posts
 ```
 
-Don't forget to tell the client your are sending JSON data:
+Don't forget to tell the client you are sending JSON data:
 
 ```php
 $data = getSomeData();


### PR DESCRIPTION
Fix an incorrect `echo` shorthand present in the PHP slides:

| Before | After |
|:-------:|:------:|
| ![image](https://github.com/arestivo/slides/assets/93825634/7e0b1a00-178b-4014-817a-c81b8ff190a5) | `<?='Hello World!'?>` |

Additionally, fix a few small issues and typos I found in the JavaScript slides, the most notable being replacing the following reference to `Map` with `Set`:

![image](https://github.com/arestivo/slides/assets/93825634/09549a14-977d-4092-94c9-acaa85be15c8)

**P.S.:** I don't remember doing so, but I accidentally typed an extra space at the end of the JavaScript slides. I feel that creating a new commit just to amend that would be overkill, so, if you do decide to merge this pull request, I would appreciate it if you could please remove it.