### PR TITLE
fix: Typo in PHP slides

### DIFF
--- a/markdown/php.md
+++ b/markdown/php.md
@@ -428,11 +428,11 @@ After finding a *true* condition, PHP continues to execute the statements until 
 ```php
 switch($name) {
   case "John":
-    do_something():
-    do_something_more():
+    do_something();
+    do_something_more();
     break;
   case "Mary":
-    do_something():
+    do_something();
     break;
   default:
     do_something_else();    


### PR DESCRIPTION
This PR corrects a typo in the PHP slides.
Replaced colons by semicolons on slide 26 to fix a syntax issue.